### PR TITLE
Fix TS definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,14 +1,17 @@
-import * as AwesomeTypescriptLoaderInterfaces from 'awesome-typescript-loader/dist/interfaces'
+import * as AwesomeTypescriptLoaderInterfaces from "awesome-typescript-loader/dist/interfaces";
 
-export type AwesomeTypescriptOptons = {
-  useCheckerPlugin?: boolean
-  loaderOptions?: AwesomeTypescriptLoaderInterfaces.LoaderConfig
+type NextConfiguration = any;
+
+export = withAwesomeTypescript;
+
+declare function withAwesomeTypescript(
+  awesomeTypescriptOptons?: withAwesomeTypescript.AwesomeTypescriptOptions,
+  nextConfiguration?: NextConfiguration
+): NextConfiguration;
+
+declare namespace withAwesomeTypescript {
+  interface AwesomeTypescriptOptions {
+    useCheckerPlugin?: boolean;
+    loaderOptions?: AwesomeTypescriptLoaderInterfaces.LoaderConfig;
+  }
 }
-
-type NextConfiguration = any
-
-export type WithAwesomeTypescript = (awesomeTypescriptOptons?: AwesomeTypescriptOptons, nextConfiguration?: NextConfiguration) => NextConfiguration
-
-declare const withAwesomeTypescript: WithAwesomeTypescript
-
-export default withAwesomeTypescript


### PR DESCRIPTION
I decided to try type checking for `next.config.js` with `// @ts-check` and noticed I was getting an error. Turns out the included TS definition uses `export default` which is incorrect since `index.js` uses `module.exports`. I updated the definition to match other ones like `@types/webpack` which is more accurate.