### PR TITLE
Support ts file and Make Its usage similar as official next-plugins

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const { CheckerPlugin } = require("awesome-typescript-loader");
 const path = require("path");
 
-module.exports = (awesomeTypescriptOptions = {}, nextConfig = {}) => {
+module.exports = (nextConfig = {}) => {
   if (!nextConfig.pageExtensions) {
     nextConfig.pageExtensions = ["jsx", "js"];
   }
@@ -23,7 +23,7 @@ module.exports = (awesomeTypescriptOptions = {}, nextConfig = {}) => {
       }
 
       const { dir, defaultLoaders, dev, isServer } = options;
-      const { useCheckerPlugin, loaderOptions } = awesomeTypescriptOptions;
+      const { useCheckerPlugin, loaderOptions } = nextConfig.awesomeTypescriptOptions;
 
       // cacheDirectory option is unavailable in case of useBabel option
       // use useCache option of awesome-typescript-loader instead

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ module.exports = (awesomeTypescriptOptions = {}, nextConfig = {}) => {
 
       if (dev && !isServer) {
         config.module.rules.push({
-          test: /\.tsx?$/,
+          test: /\.(ts|tsx)?$/,
           loader: "hot-self-accept-loader",
           include: [path.join(dir, "pages")],
           options: {
@@ -45,7 +45,7 @@ module.exports = (awesomeTypescriptOptions = {}, nextConfig = {}) => {
       }
 
       config.module.rules.push({
-        test: /\.tsx?$/,
+        test: /\.(ts|tsx)?$/,
         include: [dir],
         exclude: /node_modules/,
         use: [

--- a/readme.md
+++ b/readme.md
@@ -51,24 +51,49 @@ You can pass options to `awesome-typescript-loader` as a first argument
 // next.config.js
 const withAwesomeTypescript = require("next-awesome-typescript");
 
-const options = {
+const awesomeTypescriptOptions = {
   useCheckerPlugin: true,
   loaderOptions: {
     transpileOnly: false,
   },
 };
 
-module.exports = withAwesomeTypescript(options);
+module.exports = withAwesomeTypescript(awesomeTypescriptOptions);
 ```
 
-Optionally you can add your custom Next.js configuration as second parameter
+Optionally you can add your custom Next.js configuration as a parameter
 
 ```js
 // next.config.js
 const withAwesomeTypescript = require("next-awesome-typescript");
-const options = {};
-const nextConfiguration = {
-  webpack: () => ({}),
-};
-module.exports = withAwesomeTypescript(options, nextConfiguration);
+module.exports = withAwesomeTypescript({
+  webpack(config, options) {
+    // you can optionally add custom Next.js configuration here.
+    return config
+  },
+  awesomeTypescriptOptions: {
+    useCheckerPlugin: true,
+    loaderOptions: {
+      transpileOnly: false,
+  }}
+});
+```
+
+Probably You are not only going to use typescript plugin. In a multi plugin scenario.(In this example with next-css)
+
+```js
+// next.config.js
+const awesomeTypescriptOptions: {
+  useCheckerPlugin: true,
+  loaderOptions: {
+    transpileOnly: false,
+}}
+
+module.exports = withAwesomeTypescript(withCSS({
+  cssModules: true,
+  cssLoaderOptions: {
+    importLoaders: 1,
+  },
+  awesomeTypescriptOptions
+}));
 ```


### PR DESCRIPTION
Hi, I found that in a multi plugin composing case, Its usage is not same as official next-plugin thus I made these changes. If you want it as it is, still documentation is needed for its usage because It is not same as other official next-plugins)

**Before**
```
const options = {
  useCheckerPlugin: true,
  loaderOptions: {
    transpileOnly: false,
  },
};

module.exports = withAwesomeTypescript(options, withCSS({
  cssModules: true,
  cssLoaderOptions: {
    importLoaders: 1,
  }
}));
```

**After**
```
const awesomeTypescriptOptions = {
  useCheckerPlugin: true,
  loaderOptions: {
    transpileOnly: false,
  },
};

module.exports = withAwesomeTypescript(withCSS({
  cssModules: true,
  cssLoaderOptions: {
    importLoaders: 1,
  },
 awesomeTypescriptOptions
}));
```